### PR TITLE
Comment symbol to allow toggling comments

### DIFF
--- a/scoped-properties/language-haskell.cson
+++ b/scoped-properties/language-haskell.cson
@@ -1,4 +1,5 @@
 '.source.haskell':
   'editor':
+    'commentStart': '-- '
     'increaseIndentPattern': '((^.*(=|\\bdo|\\bwhere|\\bthen|\\belse|\\bof)\\s*$)|(^.*\\bif(?!.*\\bthen\\b.*\\belse\\b.*).*$))'
     'decreaseIndentPattern': '^\\s*$'


### PR DESCRIPTION
Allows for Cmd+/ to toggle Haskell comments.
