### PR TITLE
Fix "Lambda Expression" snippet

### DIFF
--- a/snippets/language-haskell.cson
+++ b/snippets/language-haskell.cson
@@ -10,7 +10,7 @@
     'body': '#!/usr/bin/env ${1:runhaskell}\n'
   'Lambda Expression':
     'prefix': '\\'
-    'body': '\\\\${1:pattern} -> ${0:expression}'
+    'body': '\\${1:pattern} -> ${0:expression}'
   'Left Arrow':
     'prefix': '<'
     'body': '${1:name} <- ${0:expression}'


### PR DESCRIPTION
Currently "Lambda Expression" expands to `\` to `\\pattern -> expression` but it should just be `\pattern -> expression`.
