### PR TITLE
fixed "module" keyword word-anchoring

### DIFF
--- a/grammars/haskell.cson
+++ b/grammars/haskell.cson
@@ -22,7 +22,7 @@
     'name': 'constant.language.empty-list.haskell'
   }
   {
-    'begin': '(module)'
+    'begin': '\\b(module)\\b'
     'beginCaptures':
       '1':
         'name': 'keyword.other.haskell'


### PR DESCRIPTION
Hi,

I have some identifiers in my source files that start with "module": for instance, "moduleContent", or "moduleSymbols", but the syntax highlighter tries to highlight them as a module declaration, and sometimes screws up the rest of the file as well:

![dodgy syntax highlighting](https://cloud.githubusercontent.com/assets/1696762/4475154/32571e56-4969-11e4-9b4b-82fe241f6e51.png)

To fix it, I think the "module" keyword needs to be boundary-aligned (`\b`) like some of the other keywords ("class", "instance" etc). I've implemented this in this pull request, and it seems to work.

Have a nice day!
