### PR TITLE
Add section highlighting for .cabal files

### DIFF
--- a/grammars/cabal.cson
+++ b/grammars/cabal.cson
@@ -39,7 +39,7 @@
       }
 
       {
-          'match':'(executable)\\s+(\\S+)'
+          'match': '(benchmark|executable|flag|source-repository|test-suite)\\s+(\\S+)'
           'captures':
             '1':
                 'name':'entity.name.function'


### PR DESCRIPTION
Add missing section headings for Cabal package descriptions to
the grammar file for highlighting. e.g., test-suite, flag, etc.