### PR TITLE
Fix slow 'data' declaration parsing

### DIFF
--- a/src/haskell.coffee
+++ b/src/haskell.coffee
@@ -73,7 +73,7 @@ haskellGrammar =
       ///
     ctor: concat /\b({className})\s+/,
       listMaybe('ctorArgs',/{ctorArgs}/,/\s+/)
-    typeDecl: /(?:(?:{className}|{functionName})\s*)*?(?:(?!=where)(?:{className}|{functionName}))/
+    typeDecl: /(?:{className}|{functionName})(?:\s(?:{className}|{functionName}))*/
     indentChar: /[ \t]/
     indentBlockEnd: /^(?!\1{indentChar}|{indentChar}*$)/
     maybeBirdTrack: /^/


### PR DESCRIPTION
Changing `typeDecl` from a lazy match to an equivalent greedy solved the slow parsing.

NOTE I also removed the fragment `(?!=where)` in the process. AFAIK `=where` is not important anywhere in Haskell syntax, though I could be missing something!