### PR TITLE
Add support for LiquidHaskell Annotations

### DIFF
--- a/src/haskell.coffee
+++ b/src/haskell.coffee
@@ -79,6 +79,14 @@ haskellGrammar =
     maybeBirdTrack: /^/
 
   patterns: [
+      name: 'block.liquidhaskell'
+      contentName: 'block.liquidhaskell.annotation'
+      begin: '\\{-@(?!#)'
+      end: '@-\\}'
+      patterns: [
+          include: '$self'
+      ]
+    ,
       name: 'comment.line.shebang.haskell'
       match: '^\\#\\!.*\\brunhaskell\\b.*$'
     ,
@@ -413,6 +421,7 @@ haskellGrammar =
   repository:
     block_comment:
       patterns: [
+
           name: 'comment.block.haddock.haskell'
           begin: /\{-\s*[|^]/
           end: /-\}/

--- a/src/haskell.coffee
+++ b/src/haskell.coffee
@@ -421,7 +421,6 @@ haskellGrammar =
   repository:
     block_comment:
       patterns: [
-
           name: 'comment.block.haddock.haskell'
           begin: /\{-\s*[|^]/
           end: /-\}/


### PR DESCRIPTION
Hello!

This PR adds support for LiquidHaskell's annotations, by 

1. defining a special "comment pattern" `{-@ ... @-}` 
2. highlighting the contents as code, rather than just as a comment.

Would it be possible to merge into the main `language-haskell` package? 

Its possible to spin it off in a separate package, but it makes installation 
rather cumbersome, thanks to various limitations in atom's package 
dependencies.

Many thanks for your consideration,

- Ranjit.