### PR TITLE
fix comment capture

### DIFF
--- a/grammars/haskell.cson
+++ b/grammars/haskell.cson
@@ -80,7 +80,7 @@
         'end': '(?!\\G)'
         'beginCaptures':
           '1':
-            'name': 'punctuation.whitespace.comment.leading.haskell'
+            'name': 'punctuation.whitespace.leading.haskell'
         'patterns': [
           {
             'name': 'comment.line.double-dash.haddock.haskell'
@@ -99,7 +99,7 @@
         'end': '(?!\\G)'
         'beginCaptures':
           '1':
-            'name': 'punctuation.whitespace.comment.leading.haskell'
+            'name': 'punctuation.whitespace.leading.haskell'
         'patterns': [
           {
             'name': 'comment.line.double-dash.haskell'


### PR DESCRIPTION
When using [semanticolor](https://atom.io/packages/semanticolor), or any color theme which colors comment background,

before:
![_013](https://cloud.githubusercontent.com/assets/63495/21230653/0aebd584-c2ff-11e6-802f-1ec25984a30b.png)

after:
![_014](https://cloud.githubusercontent.com/assets/63495/21230678/22f32b46-c2ff-11e6-9372-413d03dd1616.png)