### PR TITLE
Do not attempt to match newline characters

### DIFF
--- a/grammars/haskell autocompletion hint.cson
+++ b/grammars/haskell autocompletion hint.cson
@@ -87,7 +87,7 @@
           {
             'name': 'comment.line.double-dash.haddock.haskell'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.haskell'
@@ -103,7 +103,7 @@
           {
             'name': 'comment.line.double-dash.haskell'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.haskell'
@@ -773,7 +773,7 @@
       {
         'name': 'meta.preprocessor.c.haskell'
         'begin': '^(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/grammars/haskell message hint.cson
+++ b/grammars/haskell message hint.cson
@@ -109,7 +109,7 @@
           {
             'name': 'comment.line.double-dash.haddock.haskell'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.haskell'
@@ -125,7 +125,7 @@
           {
             'name': 'comment.line.double-dash.haskell'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.haskell'
@@ -795,7 +795,7 @@
       {
         'name': 'meta.preprocessor.c.haskell'
         'begin': '^(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/grammars/haskell type hint.cson
+++ b/grammars/haskell type hint.cson
@@ -84,7 +84,7 @@
           {
             'name': 'comment.line.double-dash.haddock.haskell'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.haskell'
@@ -100,7 +100,7 @@
           {
             'name': 'comment.line.double-dash.haskell'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.haskell'
@@ -770,7 +770,7 @@
       {
         'name': 'meta.preprocessor.c.haskell'
         'begin': '^(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/grammars/haskell.cson
+++ b/grammars/haskell.cson
@@ -84,7 +84,7 @@
           {
             'name': 'comment.line.double-dash.haddock.haskell'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.haskell'
@@ -100,7 +100,7 @@
           {
             'name': 'comment.line.double-dash.haskell'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.haskell'
@@ -770,7 +770,7 @@
       {
         'name': 'meta.preprocessor.c.haskell'
         'begin': '^(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/grammars/liquid haskell.cson
+++ b/grammars/liquid haskell.cson
@@ -99,7 +99,7 @@
           {
             'name': 'comment.line.double-dash.haddock.haskell'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.haskell'
@@ -115,7 +115,7 @@
           {
             'name': 'comment.line.double-dash.haskell'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.haskell'
@@ -757,7 +757,7 @@
       {
         'name': 'meta.preprocessor.c.haskell'
         'begin': '(?:\\G(?:\\s*\\w+\\s)?|^)(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/grammars/literate haskell.cson
+++ b/grammars/literate haskell.cson
@@ -37,7 +37,7 @@
   'b': '(?:(?:(?=[\\p{Ll}_\\p{Lu}\\p{Lt}])(?<![\\p{Ll}_\\p{Lu}\\p{Lt}\']))|(?:(?<=[\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\'])(?![\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\'])))'
 'patterns': [
   {
-    'begin': '^((\\\\)begin)({)(code|spec)(})(\\s*\\n)?'
+    'begin': '^((\\\\)begin)({)(code|spec)(})(\\s*$)?'
     'beginCaptures':
       '1':
         'name': 'support.function.be.latex.haskell'
@@ -141,7 +141,7 @@
           {
             'name': 'comment.line.double-dash.haddock.haskell'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.haskell'
@@ -157,7 +157,7 @@
           {
             'name': 'comment.line.double-dash.haskell'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.haskell'
@@ -827,7 +827,7 @@
       {
         'name': 'meta.preprocessor.c.haskell'
         'begin': '^(?:>|<) (?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/grammars/module signature.cson
+++ b/grammars/module signature.cson
@@ -82,7 +82,7 @@
           {
             'name': 'comment.line.double-dash.haddock.haskell.hsig'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.haskell.hsig'
@@ -98,7 +98,7 @@
           {
             'name': 'comment.line.double-dash.haskell.hsig'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.haskell.hsig'
@@ -768,7 +768,7 @@
       {
         'name': 'meta.preprocessor.c.hsig'
         'begin': '^(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/spec/haskell-record-spec.coffee
+++ b/spec/haskell-record-spec.coffee
@@ -555,17 +555,6 @@ describe 'Record', ->
                   "meta.type-signature.haskell",
                   "comment.line.double-dash.haskell"
                 ]
-              },
-              {
-                "value": "",
-                "scopes": [
-                  "source.haskell",
-                  "meta.declaration.type.data.haskell",
-                  "meta.declaration.type.data.record.block.haskell",
-                  "meta.record-field.type-declaration.haskell",
-                  "meta.type-signature.haskell",
-                  "comment.line.double-dash.haskell"
-                ]
               }
             ],
             [
@@ -593,17 +582,6 @@ describe 'Record', ->
               },
               {
                 "value": " model :: String, -- commented field",
-                "scopes": [
-                  "source.haskell",
-                  "meta.declaration.type.data.haskell",
-                  "meta.declaration.type.data.record.block.haskell",
-                  "meta.record-field.type-declaration.haskell",
-                  "meta.type-signature.haskell",
-                  "comment.line.double-dash.haskell"
-                ]
-              },
-              {
-                "value": "",
                 "scopes": [
                   "source.haskell",
                   "meta.declaration.type.data.haskell",
@@ -700,17 +678,6 @@ describe 'Record', ->
               },
               {
                 "value": " another comment",
-                "scopes": [
-                  "source.haskell",
-                  "meta.declaration.type.data.haskell",
-                  "meta.declaration.type.data.record.block.haskell",
-                  "meta.record-field.type-declaration.haskell",
-                  "meta.type-signature.haskell",
-                  "comment.line.double-dash.haskell"
-                ]
-              },
-              {
-                "value": "",
                 "scopes": [
                   "source.haskell",
                   "meta.declaration.type.data.haskell",
@@ -847,15 +814,6 @@ describe 'Record', ->
           },
           {
             "value": " company :: String",
-            "scopes": [
-              "source.haskell",
-              "meta.declaration.type.data.haskell",
-              "meta.declaration.type.data.record.block.haskell",
-              "comment.line.double-dash.haskell"
-            ]
-          },
-          {
-            "value": "",
             "scopes": [
               "source.haskell",
               "meta.declaration.type.data.haskell",

--- a/spec/language-haskell-spec.coffee
+++ b/spec/language-haskell-spec.coffee
@@ -513,10 +513,9 @@ describe "Language-Haskell", ->
   describe "regression test for comments after module name in imports", ->
     it "parses comments after module names", ->
       g = grammarExpect grammar, 'import Module -- comment'
-      g.toHaveTokens [['import', ' ', 'Module', ' ', '--', ' comment', '']]
+      g.toHaveTokens [['import', ' ', 'Module', ' ', '--', ' comment']]
       g.toHaveScopes [['source.haskell', 'meta.import.haskell']]
       g.tokenToHaveScopes [[[2, ['support.other.module.haskell']]
                             [4, ['comment.line.double-dash.haskell', 'punctuation.definition.comment.haskell']]
                             [5, ['comment.line.double-dash.haskell']]
-                            [6, ['comment.line.double-dash.haskell']]
                             ]]

--- a/src/include/lhs-patterns.coffee
+++ b/src/include/lhs-patterns.coffee
@@ -1,6 +1,6 @@
 module.exports =
   [
-      begin: /^((\\)begin)({)(code|spec)(})(\s*\n)?/
+      begin: /^((\\)begin)({)(code|spec)(})(\s*$)?/
       beginCaptures:
         1:
           name: 'support.function.be.latex'

--- a/src/include/repository.coffee
+++ b/src/include/repository.coffee
@@ -36,7 +36,7 @@ module.exports=
         patterns: [
             name: 'comment.line.double-dash.haddock.haskell'
             begin: /(--+)\s+([|^])/
-            end: /\n/
+            end: /$/
             beginCaptures:
               1: name: 'punctuation.definition.comment.haskell'
               2: name: 'punctuation.definition.comment.haddock.haskell'
@@ -52,7 +52,7 @@ module.exports=
         patterns: [
             name: 'comment.line.double-dash.haskell'
             begin: /--/
-            end: /\n/
+            end: /$/
             beginCaptures:
               0: name: 'punctuation.definition.comment.haskell'
         ]
@@ -430,7 +430,7 @@ module.exports=
   c_preprocessor:
     name: 'meta.preprocessor.c'
     begin: /{maybeBirdTrack}(?=#)/
-    end: '(?<!\\\\)(?=\\n)'
+    end: '(?<!\\\\)(?=$)'
     patterns: [
       include: 'source.c'
     ]


### PR DESCRIPTION
This PR replaces all \n end matches with $. The two are nearly identical, with the only difference being that $ does not create a zero-width match at the end of the line. These changes are mainly required due to atom/first-mate#100, as newlines are no longer added to the last line of the file. Therefore, this change is simply a backwards-compatible change to ensure that language-haskell continues working as before on Atom 1.22+.

I hope I did the whole grammar generation correctly!

/cc @Ingramz

Refs atom/atom#15729