### PR TITLE
Patch numeric underscores

### DIFF
--- a/grammars/haskell autocompletion hint.cson
+++ b/grammars/haskell autocompletion hint.cson
@@ -913,27 +913,27 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
+        'match': '0[xX][_0-9a-fA-F]+'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO]_*[0-7](_*[0-7])*'
+        'match': '0[oO][_0-7]+'
       }
       {
         'name': 'constant.numeric.binary.haskell'
-        'match': '0[bB]_*[01](_*[01])*'
+        'match': '0[bB][_01]+'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9](_*[0-9])*'
+        'match': '[0-9][_0-9]*'
       }
     ]
   'operator':

--- a/grammars/haskell autocompletion hint.cson
+++ b/grammars/haskell autocompletion hint.cson
@@ -913,7 +913,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+(?:[pP][+-]?[0-9_]+)?|[pP][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -929,7 +929,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+(?:[eE][+-]?[0-9_]+)?|[eE][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/haskell autocompletion hint.cson
+++ b/grammars/haskell autocompletion hint.cson
@@ -913,7 +913,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
+        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -929,7 +929,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
+        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/haskell autocompletion hint.cson
+++ b/grammars/haskell autocompletion hint.cson
@@ -912,20 +912,28 @@
   'lit_num':
     'patterns': [
       {
+        'name': 'constant.numeric.hexfloat.haskell'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+      }
+      {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX][0-9a-fA-F]+'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO][0-7]+'
+        'match': '0[oO]_*[0-7](_*[0-7])*'
+      }
+      {
+        'name': 'constant.numeric.binary.haskell'
+        'match': '0[bB]_*[01](_*[01])*'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9]+(\\.[0-9]+[eE][+-]?|\\.|[eE][+-]?)[0-9]+'
+        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9]+'
+        'match': '[0-9](_*[0-9])*'
       }
     ]
   'operator':

--- a/grammars/haskell message hint.cson
+++ b/grammars/haskell message hint.cson
@@ -934,20 +934,28 @@
   'lit_num':
     'patterns': [
       {
+        'name': 'constant.numeric.hexfloat.haskell'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+      }
+      {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX][0-9a-fA-F]+'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO][0-7]+'
+        'match': '0[oO]_*[0-7](_*[0-7])*'
+      }
+      {
+        'name': 'constant.numeric.binary.haskell'
+        'match': '0[bB]_*[01](_*[01])*'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9]+(\\.[0-9]+[eE][+-]?|\\.|[eE][+-]?)[0-9]+'
+        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9]+'
+        'match': '[0-9](_*[0-9])*'
       }
     ]
   'operator':

--- a/grammars/haskell message hint.cson
+++ b/grammars/haskell message hint.cson
@@ -935,7 +935,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
+        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -951,7 +951,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
+        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/haskell message hint.cson
+++ b/grammars/haskell message hint.cson
@@ -935,27 +935,27 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
+        'match': '0[xX][_0-9a-fA-F]+'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO]_*[0-7](_*[0-7])*'
+        'match': '0[oO][_0-7]+'
       }
       {
         'name': 'constant.numeric.binary.haskell'
-        'match': '0[bB]_*[01](_*[01])*'
+        'match': '0[bB][_01]+'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9](_*[0-9])*'
+        'match': '[0-9][_0-9]*'
       }
     ]
   'operator':

--- a/grammars/haskell message hint.cson
+++ b/grammars/haskell message hint.cson
@@ -935,7 +935,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+(?:[pP][+-]?[0-9_]+)?|[pP][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -951,7 +951,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+(?:[eE][+-]?[0-9_]+)?|[eE][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/haskell type hint.cson
+++ b/grammars/haskell type hint.cson
@@ -910,7 +910,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
+        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -926,7 +926,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
+        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/haskell type hint.cson
+++ b/grammars/haskell type hint.cson
@@ -910,27 +910,27 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
+        'match': '0[xX][_0-9a-fA-F]+'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO]_*[0-7](_*[0-7])*'
+        'match': '0[oO][_0-7]+'
       }
       {
         'name': 'constant.numeric.binary.haskell'
-        'match': '0[bB]_*[01](_*[01])*'
+        'match': '0[bB][_01]+'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9](_*[0-9])*'
+        'match': '[0-9][_0-9]*'
       }
     ]
   'operator':

--- a/grammars/haskell type hint.cson
+++ b/grammars/haskell type hint.cson
@@ -909,20 +909,28 @@
   'lit_num':
     'patterns': [
       {
+        'name': 'constant.numeric.hexfloat.haskell'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+      }
+      {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX][0-9a-fA-F]+'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO][0-7]+'
+        'match': '0[oO]_*[0-7](_*[0-7])*'
+      }
+      {
+        'name': 'constant.numeric.binary.haskell'
+        'match': '0[bB]_*[01](_*[01])*'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9]+(\\.[0-9]+[eE][+-]?|\\.|[eE][+-]?)[0-9]+'
+        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9]+'
+        'match': '[0-9](_*[0-9])*'
       }
     ]
   'operator':

--- a/grammars/haskell type hint.cson
+++ b/grammars/haskell type hint.cson
@@ -910,7 +910,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+(?:[pP][+-]?[0-9_]+)?|[pP][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -926,7 +926,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+(?:[eE][+-]?[0-9_]+)?|[eE][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/haskell.cson
+++ b/grammars/haskell.cson
@@ -910,7 +910,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
+        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -926,7 +926,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
+        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/haskell.cson
+++ b/grammars/haskell.cson
@@ -910,27 +910,27 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
+        'match': '0[xX][_0-9a-fA-F]+'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO]_*[0-7](_*[0-7])*'
+        'match': '0[oO][_0-7]+'
       }
       {
         'name': 'constant.numeric.binary.haskell'
-        'match': '0[bB]_*[01](_*[01])*'
+        'match': '0[bB][_01]+'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9](_*[0-9])*'
+        'match': '[0-9][_0-9]*'
       }
     ]
   'operator':

--- a/grammars/haskell.cson
+++ b/grammars/haskell.cson
@@ -909,20 +909,28 @@
   'lit_num':
     'patterns': [
       {
+        'name': 'constant.numeric.hexfloat.haskell'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+      }
+      {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX][0-9a-fA-F]+'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO][0-7]+'
+        'match': '0[oO]_*[0-7](_*[0-7])*'
+      }
+      {
+        'name': 'constant.numeric.binary.haskell'
+        'match': '0[bB]_*[01](_*[01])*'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9]+(\\.[0-9]+[eE][+-]?|\\.|[eE][+-]?)[0-9]+'
+        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9]+'
+        'match': '[0-9](_*[0-9])*'
       }
     ]
   'operator':

--- a/grammars/haskell.cson
+++ b/grammars/haskell.cson
@@ -910,7 +910,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+(?:[pP][+-]?[0-9_]+)?|[pP][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -926,7 +926,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+(?:[eE][+-]?[0-9_]+)?|[eE][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/liquid haskell.cson
+++ b/grammars/liquid haskell.cson
@@ -897,27 +897,27 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
+        'match': '0[xX][_0-9a-fA-F]+'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO]_*[0-7](_*[0-7])*'
+        'match': '0[oO][_0-7]+'
       }
       {
         'name': 'constant.numeric.binary.haskell'
-        'match': '0[bB]_*[01](_*[01])*'
+        'match': '0[bB][_01]+'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9](_*[0-9])*'
+        'match': '[0-9][_0-9]*'
       }
     ]
   'operator':

--- a/grammars/liquid haskell.cson
+++ b/grammars/liquid haskell.cson
@@ -896,20 +896,28 @@
   'lit_num':
     'patterns': [
       {
+        'name': 'constant.numeric.hexfloat.haskell'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+      }
+      {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX][0-9a-fA-F]+'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO][0-7]+'
+        'match': '0[oO]_*[0-7](_*[0-7])*'
+      }
+      {
+        'name': 'constant.numeric.binary.haskell'
+        'match': '0[bB]_*[01](_*[01])*'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9]+(\\.[0-9]+[eE][+-]?|\\.|[eE][+-]?)[0-9]+'
+        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9]+'
+        'match': '[0-9](_*[0-9])*'
       }
     ]
   'operator':

--- a/grammars/liquid haskell.cson
+++ b/grammars/liquid haskell.cson
@@ -897,7 +897,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+(?:[pP][+-]?[0-9_]+)?|[pP][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -913,7 +913,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+(?:[eE][+-]?[0-9_]+)?|[eE][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/liquid haskell.cson
+++ b/grammars/liquid haskell.cson
@@ -897,7 +897,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
+        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -913,7 +913,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
+        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/literate haskell.cson
+++ b/grammars/literate haskell.cson
@@ -967,7 +967,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+(?:[pP][+-]?[0-9_]+)?|[pP][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -983,7 +983,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+(?:[eE][+-]?[0-9_]+)?|[eE][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/literate haskell.cson
+++ b/grammars/literate haskell.cson
@@ -967,27 +967,27 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
+        'match': '0[xX][_0-9a-fA-F]+'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO]_*[0-7](_*[0-7])*'
+        'match': '0[oO][_0-7]+'
       }
       {
         'name': 'constant.numeric.binary.haskell'
-        'match': '0[bB]_*[01](_*[01])*'
+        'match': '0[bB][_01]+'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9](_*[0-9])*'
+        'match': '[0-9][_0-9]*'
       }
     ]
   'operator':

--- a/grammars/literate haskell.cson
+++ b/grammars/literate haskell.cson
@@ -967,7 +967,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell'
-        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
+        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell'
@@ -983,7 +983,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
+        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell'

--- a/grammars/literate haskell.cson
+++ b/grammars/literate haskell.cson
@@ -966,20 +966,28 @@
   'lit_num':
     'patterns': [
       {
+        'name': 'constant.numeric.hexfloat.haskell'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+      }
+      {
         'name': 'constant.numeric.hexadecimal.haskell'
-        'match': '0[xX][0-9a-fA-F]+'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
       }
       {
         'name': 'constant.numeric.octal.haskell'
-        'match': '0[oO][0-7]+'
+        'match': '0[oO]_*[0-7](_*[0-7])*'
+      }
+      {
+        'name': 'constant.numeric.binary.haskell'
+        'match': '0[bB]_*[01](_*[01])*'
       }
       {
         'name': 'constant.numeric.float.haskell'
-        'match': '[0-9]+(\\.[0-9]+[eE][+-]?|\\.|[eE][+-]?)[0-9]+'
+        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
       }
       {
         'name': 'constant.numeric.decimal.haskell'
-        'match': '[0-9]+'
+        'match': '[0-9](_*[0-9])*'
       }
     ]
   'operator':

--- a/grammars/module signature.cson
+++ b/grammars/module signature.cson
@@ -908,7 +908,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell.hsig'
-        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
+        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell.hsig'
@@ -924,7 +924,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell.hsig'
-        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
+        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell.hsig'

--- a/grammars/module signature.cson
+++ b/grammars/module signature.cson
@@ -908,27 +908,27 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell.hsig'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+[pP][+-]?|\\.|[pP][+-]?)[0-9a-fA-F_]+'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell.hsig'
-        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
+        'match': '0[xX][_0-9a-fA-F]+'
       }
       {
         'name': 'constant.numeric.octal.haskell.hsig'
-        'match': '0[oO]_*[0-7](_*[0-7])*'
+        'match': '0[oO][_0-7]+'
       }
       {
         'name': 'constant.numeric.binary.haskell.hsig'
-        'match': '0[bB]_*[01](_*[01])*'
+        'match': '0[bB][_01]+'
       }
       {
         'name': 'constant.numeric.float.haskell.hsig'
-        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+[eE][+-]?|\\.|[eE][+-]?)[0-9_]+'
       }
       {
         'name': 'constant.numeric.decimal.haskell.hsig'
-        'match': '[0-9](_*[0-9])*'
+        'match': '[0-9][_0-9]*'
       }
     ]
   'operator':

--- a/grammars/module signature.cson
+++ b/grammars/module signature.cson
@@ -907,20 +907,28 @@
   'lit_num':
     'patterns': [
       {
+        'name': 'constant.numeric.hexfloat.haskell.hsig'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+      }
+      {
         'name': 'constant.numeric.hexadecimal.haskell.hsig'
-        'match': '0[xX][0-9a-fA-F]+'
+        'match': '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
       }
       {
         'name': 'constant.numeric.octal.haskell.hsig'
-        'match': '0[oO][0-7]+'
+        'match': '0[oO]_*[0-7](_*[0-7])*'
+      }
+      {
+        'name': 'constant.numeric.binary.haskell.hsig'
+        'match': '0[bB]_*[01](_*[01])*'
       }
       {
         'name': 'constant.numeric.float.haskell.hsig'
-        'match': '[0-9]+(\\.[0-9]+[eE][+-]?|\\.|[eE][+-]?)[0-9]+'
+        'match': '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
       }
       {
         'name': 'constant.numeric.decimal.haskell.hsig'
-        'match': '[0-9]+'
+        'match': '[0-9](_*[0-9])*'
       }
     ]
   'operator':

--- a/grammars/module signature.cson
+++ b/grammars/module signature.cson
@@ -908,7 +908,7 @@
     'patterns': [
       {
         'name': 'constant.numeric.hexfloat.haskell.hsig'
-        'match': '0[xX][0-9a-fA-F_]*(?:(?:\\.[0-9a-fA-F_]+)?[pP][+-]?[0-9_]+|\\.[0-9a-fA-F_]+)'
+        'match': '0[xX][0-9a-fA-F_]*(?:\\.[0-9a-fA-F_]+(?:[pP][+-]?[0-9_]+)?|[pP][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.hexadecimal.haskell.hsig'
@@ -924,7 +924,7 @@
       }
       {
         'name': 'constant.numeric.float.haskell.hsig'
-        'match': '[0-9][0-9_]*(?:(?:\\.[0-9_]+)?[eE][+-]?[0-9_]+|\\.[0-9_]+)'
+        'match': '[0-9][0-9_]*(?:\\.[0-9_]+(?:[eE][+-]?[0-9_]+)?|[eE][+-]?[0-9_]+)'
       }
       {
         'name': 'constant.numeric.decimal.haskell.hsig'

--- a/src/include/repository.coffee
+++ b/src/include/repository.coffee
@@ -1,6 +1,6 @@
 prelude = require './prelude'
 pragmas = require './pragmas'
-{ balanced } = require './util'
+{ balanced, floatPattern } = require './util'
 
 module.exports=
   block_comment:
@@ -497,22 +497,22 @@ module.exports=
     match: /,/
   lit_num: [
     name: 'constant.numeric.hexfloat.haskell'
-    match: '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+    match: "0[xX]#{floatPattern('[0-9a-fA-F_]','[pP]')}"
   ,
     name: 'constant.numeric.hexadecimal.haskell'
-    match: '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
+    match: '0[xX][_0-9a-fA-F]+'
   ,
     name: 'constant.numeric.octal.haskell'
-    match: '0[oO]_*[0-7](_*[0-7])*'
+    match: '0[oO][_0-7]+'
   ,
     name: 'constant.numeric.binary.haskell'
-    match: '0[bB]_*[01](_*[01])*'
+    match: '0[bB][_01]+'
   ,
     name: 'constant.numeric.float.haskell'
-    match: '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
+    match: "[0-9]#{floatPattern('[0-9_]', '[eE]')}"
   ,
     name: 'constant.numeric.decimal.haskell'
-    match: '[0-9](_*[0-9])*'
+    match: '[0-9][_0-9]*'
   ]
   operator:
     name: 'keyword.operator.haskell'

--- a/src/include/repository.coffee
+++ b/src/include/repository.coffee
@@ -496,17 +496,23 @@ module.exports=
     name: 'punctuation.separator.comma.haskell'
     match: /,/
   lit_num: [
+    name: 'constant.numeric.hexfloat.haskell'
+    match: '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*((\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][+-]?[0-9](_*[0-9])*)*)|(_*[pP][+-]?[0-9](_*[0-9])*))'
+  ,
     name: 'constant.numeric.hexadecimal.haskell'
-    match: '0[xX][0-9a-fA-F]+'
+    match: '0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*'
   ,
     name: 'constant.numeric.octal.haskell'
-    match: '0[oO][0-7]+'
+    match: '0[oO]_*[0-7](_*[0-7])*'
+  ,
+    name: 'constant.numeric.binary.haskell'
+    match: '0[bB]_*[01](_*[01])*'
   ,
     name: 'constant.numeric.float.haskell'
-    match: '[0-9]+(\\.[0-9]+[eE][+-]?|\\.|[eE][+-]?)[0-9]+'
+    match: '[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*_*[eE][+-]?|\\.|_*[eE][+-]?)[0-9](_*[0-9])*'
   ,
     name: 'constant.numeric.decimal.haskell'
-    match: '[0-9]+'
+    match: '[0-9](_*[0-9])*'
   ]
   operator:
     name: 'keyword.operator.haskell'

--- a/src/include/util.coffee
+++ b/src/include/util.coffee
@@ -22,4 +22,7 @@ balanced = (name, left, right, inner, ignore = '') ->
   else
     "(?<#{name}>(?:[^#{left}#{right}#{ignore}]|#{left}\\g<#{name}>#{right})*)"
 
-module.exports = {list, listMaybe, concat, balanced}
+floatPattern = (digit, exp) ->
+  "#{digit}*(?:\\.#{digit}+#{exp}[+-]?|\\.|#{exp}[+-]?)#{digit}+"
+
+module.exports = {list, listMaybe, concat, balanced, floatPattern}

--- a/src/include/util.coffee
+++ b/src/include/util.coffee
@@ -23,6 +23,7 @@ balanced = (name, left, right, inner, ignore = '') ->
     "(?<#{name}>(?:[^#{left}#{right}#{ignore}]|#{left}\\g<#{name}>#{right})*)"
 
 floatPattern = (digit, exp) ->
-  "#{digit}*(?:\\.#{digit}+#{exp}[+-]?|\\.|#{exp}[+-]?)#{digit}+"
+  "#{digit}*(?:(?:\\.#{digit}+)?#{exp}[+-]?[0-9_]+|\\.#{digit}+)"
+
 
 module.exports = {list, listMaybe, concat, balanced, floatPattern}

--- a/src/include/util.coffee
+++ b/src/include/util.coffee
@@ -23,7 +23,7 @@ balanced = (name, left, right, inner, ignore = '') ->
     "(?<#{name}>(?:[^#{left}#{right}#{ignore}]|#{left}\\g<#{name}>#{right})*)"
 
 floatPattern = (digit, exp) ->
-  "#{digit}*(?:(?:\\.#{digit}+)?#{exp}[+-]?[0-9_]+|\\.#{digit}+)"
-
+  exponent = "#{exp}[+-]?[0-9_]+"
+  "#{digit}*(?:\\.#{digit}+(?:#{exponent})?|#{exponent})"
 
 module.exports = {list, listMaybe, concat, balanced, floatPattern}


### PR DESCRIPTION
Dear authors,

Sorry if it is not the correct procedure.
Could you please fix this for syntax highlighting of numeric literals?

This patch contains three fixes:

* Add constant.numeric.hexfloat.haskell for HexFloatLiterals extension [1]
* Add constant.numeric.binary.haskell for BinaryLiterals extension [2]
* Modify lit_num for NumericUnderscores extension [3] [4]


I visually checked this patch with the these files [5] [6].

[1]: https://ghc.haskell.org/trac/ghc/ticket/9224
[2]: https://ghc.haskell.org/trac/ghc/ticket/13126
[3]: https://ghc.haskell.org/trac/ghc/ticket/14473
[4]: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0009-numeric-underscores.rst
[5]: https://github.com/takenobu-hs/ghc/blob/squashed-numeric-underscores/testsuite/tests/parser/should_run/NumericUnderscores0.hs
[6]: https://github.com/takenobu-hs/ghc/blob/squashed-numeric-underscores/testsuite/tests/parser/should_run/NumericUnderscores1.hs

Thanks for your wonderful work