### PR TITLE
Detect .hs-boot and cabal.project/cabal.project.local file types

### DIFF
--- a/grammars/cabal.cson
+++ b/grammars/cabal.cson
@@ -1,6 +1,8 @@
 'scopeName': 'source.cabal'
 'fileTypes': [
   'cabal'
+  'cabal.project'
+  'cabal.project.local'
 ]
 'name': 'Cabal'
 'patterns': [

--- a/grammars/haskell.cson
+++ b/grammars/haskell.cson
@@ -1,5 +1,6 @@
 'fileTypes': [
   'hs'
+  'hs-boot'
   'cpphs'
 ]
 'firstLineMatch': '^\\#\\!.*\\brunhaskell\\b'

--- a/src/haskell.coffee
+++ b/src/haskell.coffee
@@ -3,7 +3,7 @@ _ = require 'underscore-plus'
 
 makeGrammar "grammars/haskell.cson",
   name: 'Haskell'
-  fileTypes: [ 'hs', 'cpphs' ]
+  fileTypes: [ 'hs', 'hs-boot', 'cpphs' ]
   firstLineMatch: '^\\#\\!.*\\brunhaskell\\b'
   scopeName: 'source.haskell'
 


### PR DESCRIPTION
This PR adds two (or three, depending on how you count) additional file type registrations:

  1. `hs-boot` is detected as `source.haskell`, for [mutually-recursive modules](https://downloads.haskell.org/ghc/8.10.3/docs/html/users_guide/separate_compilation.html#how-to-compile-mutually-recursive-modules).

  2. `cabal.project` and `cabal.project.local` are detected as `source.cabal`, for [cabal project configuration files](https://cabal.readthedocs.io/en/3.4/cabal-project.html).